### PR TITLE
Use correct file extension for build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,14 +80,14 @@ jobs:
         working-directory: pyodide_checkout/
         run: |
           python tools/create_xbuildenv.py .
-          tar cjf xbuildenv.tar.gz ./xbuildenv/
+          tar cjf xbuildenv.tar.bz ./xbuildenv/
 
       - name: Upload cross-build environment
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: cross-build-env
           path: |
-            pyodide_checkout/xbuildenv.tar.gz
+            pyodide_checkout/xbuildenv.tar.bz
           if-no-files-found: error
           retention-days: 1
 
@@ -115,14 +115,14 @@ jobs:
         uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
         with:
           subject-path: |
-            dist/xbuildenv.tar.gz
+            dist/xbuildenv.tar.bz
 
       - name: Verify them, to ensure that the wheels they were attested correctly
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh attestation verify dist/xbuildenv.tar.gz --repo ${{ github.repository }}
+          gh attestation verify dist/xbuildenv.tar.bz --repo ${{ github.repository }}
 
       - name: Create GitHub release with these wheels
         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
@@ -132,6 +132,6 @@ jobs:
           github.event.action == 'published'
         with:
           files: |
-            dist/*.tar.gz
+            dist/*.tar.bz
           fail_on_unmatched_files: true
           name: Pyodide cross-build environment


### PR DESCRIPTION
It's a bzip file, but written out as .tar.gz, which means pyodide build can't load it correctly.

I just did find/replace in the action - I don't think I broke anything, but worth someone who knows better than me checking it actually works.