### PR TITLE
Add release and debug build variants for xbuildenvs

### DIFF
--- a/.github/workflows/build-xbuildenv.yml
+++ b/.github/workflows/build-xbuildenv.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [release, debug]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       

--- a/.github/workflows/build-xbuildenv.yml
+++ b/.github/workflows/build-xbuildenv.yml
@@ -64,6 +64,10 @@ jobs:
 
       - run: echo "PYODIDE_JOBS=$(nproc)" >> "$GITHUB_ENV"
 
+      - name: Set debug environment
+        if: matrix.build_type == 'debug'
+        run: echo "PYODIDE_DEBUG=1" >> "$GITHUB_ENV"
+
       - name: Build Pyodide packages with NumPy v2 enabled
         working-directory: pyodide_checkout/
         run: |
@@ -85,13 +89,17 @@ jobs:
         working-directory: pyodide_checkout/
         run: |
           python tools/create_xbuildenv.py .
-          tar cjf xbuildenv.tar.bz2 ./xbuildenv/
+          if [[ "${{ matrix.build_type }}" == "debug" ]]; then
+            tar cjf xbuildenv-debug.tar.bz2 ./xbuildenv/
+          else
+            tar cjf xbuildenv.tar.bz2 ./xbuildenv/
+          fi
 
       - name: Upload cross-build environment
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
-          name: cross-build-env
+          name: cross-build-env${{ matrix.build_type == 'debug' && '-debug' || '' }}
           path: |
-            pyodide_checkout/xbuildenv.tar.bz2
+            pyodide_checkout/xbuildenv*.tar.bz2
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/build-xbuildenv.yml
+++ b/.github/workflows/build-xbuildenv.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: /tmp/ccache
-          key: ccache-${{ hashFiles('Makefile.envs') }}
+          key: ccache-${{ matrix.build_type == 'debug' && 'debug-' || '' }}${{ hashFiles('Makefile.envs') }}
 
       - name: Checkout Pyodide
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -60,7 +60,7 @@ jobs:
             pyodide_checkout/packages/.libs/*
             pyodide_checkout/packages/.artifacts/*
             pyodide_checkout/dist/*.whl
-          key: pyodide-packages-${{ hashFiles('pyodide_checkout/packages/recipes/**/*.yaml') }}
+          key: pyodide-packages-${{ matrix.build_type == 'debug' && 'debug-' || '' }}${{ hashFiles('pyodide_checkout/packages/recipes/**/*.yaml') }}
 
       - run: echo "PYODIDE_JOBS=$(nproc)" >> "$GITHUB_ENV"
 
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: /tmp/ccache
-          key: ccache-${{ hashFiles('Makefile.envs') }}
+          key: ccache-${{ matrix.build_type == 'debug' && 'debug-' || '' }}${{ hashFiles('Makefile.envs') }}
 
       - name: Create cross-build environment
         working-directory: pyodide_checkout/

--- a/.github/workflows/build-xbuildenv.yml
+++ b/.github/workflows/build-xbuildenv.yml
@@ -64,11 +64,7 @@ jobs:
 
       - run: echo "PYODIDE_JOBS=$(nproc)" >> "$GITHUB_ENV"
 
-      - name: Set debug environment
-        if: matrix.build_type == 'debug'
-        run: echo "PYODIDE_DEBUG=1" >> "$GITHUB_ENV"
-
-      - name: Build Pyodide packages with NumPy v2 enabled
+      - name: Build Pyodide packages with NumPy v2 enabled (release version)
         working-directory: pyodide_checkout/
         run: |
           source pyodide_env.sh
@@ -78,6 +74,20 @@ jobs:
           pip install -e ./pyodide-build
           PYODIDE_PACKAGES="numpy,scipy,cffi" make
           ccache -s
+
+      - name: Build debug version
+        if: matrix.build_type == 'debug'
+        working-directory: pyodide_checkout/
+        run: |
+          rm dist/pyodide.asm.js
+          source pyodide_env.sh
+          ccache -z
+          PYODIDE_DEBUG=1 make dist/pyodide.asm.js
+          ccache -s
+          pushd dist
+          npx prettier -w pyodide.asm.js
+          npx prettier -w pyodide.js
+          popd
 
       - name: Save ccached outputs
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,12 +47,19 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: cross-build-env-debug
+          path: dist
+          merge-multiple: true
+
       - name: Generate attestations
         uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
         with:
           subject-path: |
             dist/xbuildenv.tar.bz2
-      
+            dist/xbuildenv-debug.tar.bz2
+
       - name: Calc release version
         id: release_version
         shell: bash
@@ -71,6 +78,7 @@ jobs:
         shell: bash
         run: |
           gh attestation verify dist/xbuildenv.tar.bz2 --repo ${{ github.repository }}
+          gh attestation verify dist/xbuildenv-debug.tar.bz2 --repo ${{ github.repository }}
       
       - name: Create and push tag
         run: |

--- a/README.md
+++ b/README.md
@@ -10,15 +10,35 @@ The target user of this repository is package maintainers who want to build thei
 Each release in this repository contains a tip-of-tree build of Pyodide of the given date.
 You can use the `pyodide xbuildenv install` command to install the build environment for a given date.
 
+### Cross build environments
+
+#### Release builds
+
 ```bash
 pip install pyodide-build
 
 # Change the date to the date of the build you want to use
-pyodide xbuildenv install --url "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250125/xbuildenv.tar.bz"
+pyodide xbuildenv install --url "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250125/xbuildenv.tar.bz2"
 
 # Now you can use the build environment to build your package
 pyodide build
 ```
+
+#### Debug builds
+
+For debugging purposes, you can also use the debug build environment:
+
+```bash
+pip install pyodide-build
+
+# Change the date to the date of the build you want to use
+pyodide xbuildenv install --url "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250125/xbuildenv-debug.tar.bz2"
+
+# Now you can use the debug build environment to build your package
+pyodide build
+```
+
+The debug build environment is built with `PYODIDE_DEBUG=1` and includes additional debugging information.
 
 ## Maintainer Notes
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pyodide build
 
 #### Debug builds
 
-For debugging purposes, you can also use the debug build environment:
+For debugging purposes, you can also use the debug version of the cross build environment:
 
 ```bash
 pip install pyodide-build
@@ -34,11 +34,16 @@ pip install pyodide-build
 # Change the date to the date of the build you want to use
 pyodide xbuildenv install --url "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250125/xbuildenv-debug.tar.bz2"
 
-# Now you can use the debug build environment to build your package
+# Now you can use the build environment to build your package
 pyodide build
 ```
 
-The debug build environment is built with `PYODIDE_DEBUG=1` and includes additional debugging information.
+The debug cross build environment is built with `PYODIDE_DEBUG=1` and provides additional debugging information.
+
+> [!NOTE]
+> The debug build does not make a difference in the build process itself. It is useful if you use the Pyodide CLI runner (`pyodide venv`), as
+it will automatically use the installed debug cross build environment for the Pyodide runtime and provide additional debugging information. To
+remove the debug build environment, you may use the `pyodide xbuildenv uninstall` command.
 
 ## Maintainer Notes
 


### PR DESCRIPTION
This PR adds release and debug build variants for xbuildenv artifacts for upcoming releases. We use a matrix to build them, and we rename the cache keys and artifact names accordingly. I also updated the docs to reflect this, as on second thought I felt this might be useful for others as well, but please let me know if I should split it to a different PR or keep for later. Thanks!

One of the many follow-ups here that we could take here could be to simplify how we interact with URLs; i.e., instead of having to type out the full URL for installation, we could allow `pyodide xbuildenv install nightly-YYYY-MM-DD --type debug|release` and handle the URLs internally.