### PR TITLE
Establish v2 spec nightly metadata on GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Cross-build environment for pyodide-build
+name: Build
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ jobs:
   build:
     permissions:
       contents: read
-    name: Build cross-build environment for Pyodide
+    name: Build xbuildenv
     uses: ./.github/workflows/build-xbuildenv.yml
     with:
       branch: ${{ github.event.inputs.branch || 'main' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy metadata to GitHub Pages
+name: Deploy nightly environments metadata to GitHub Pages
 
 on:
   push:
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   deploy:
+    name: Deploy nightly environments metadata to GitHub Pages
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,30 +8,26 @@ on:
       - "nightly-cross-build-environments.json"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy nightly environments metadata to GitHub Pages
+  build:
+    name: Build GitHub Pages artifacts
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}/api/v2/nightly-cross-build-environments.json
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       # We don't actually have a v1 API here, just that we do it to be in line with the
-      # non-nightly metadata
-      - name: Prepare Pages content
+      # non-nightly metadata in the pyodide/pyodide GitHub Pages job/site
+      - name: Prepare GitHub Pages content
         run: |
           mkdir -p _site/api/v2
           cp nightly-cross-build-environments.json _site/api/v2
@@ -40,6 +36,17 @@ jobs:
         with:
           path: _site
 
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      pages: write # Required to deploy to GitHub Pages
+      id-token: write # Required for OIDC token used by the deploy-pages action
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}/api/v2/nightly-cross-build-environments.json
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy metadata to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "nightly-cross-build-environments.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}/api/v2/nightly-cross-build-environments.json
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      # We don't actually have a v1 API here, just that we do it to be in line with the
+      # non-nightly metadata
+      - name: Prepare Pages content
+        run: |
+          mkdir -p _site/api/v2
+          cp nightly-cross-build-environments.json _site/api/v2
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,3 +112,27 @@ jobs:
           tag_name: ${{ steps.release_version.outputs.release_version }}
           fail_on_unmatched_files: true
           name: ${{ steps.release_version.outputs.release_version }}
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Update cross-build environments metadata
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release_version.outputs.release_version }}
+        run: uv run tools/update_nightly_cross_build_releases.py "$VERSION"
+
+      - name: Commit and push metadata updates
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release_version.outputs.release_version }}
+        run: |
+          gh auth setup-git
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add nightly-cross-build-environments.json
+          git commit -m "Scheduled update for nightly  ${VERSION} xbuildenvs metadata [skip ci]"
+          git push origin main

--- a/nightly-cross-build-environments.json
+++ b/nightly-cross-build-environments.json
@@ -1,0 +1,544 @@
+{
+  "releases": {
+    "20260520": {
+      "version": "20260520",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260520/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260520/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-05-20T04:40:12Z"
+    },
+    "20260510": {
+      "version": "20260510",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260510/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260510/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-05-10T04:22:58Z"
+    },
+    "20260501": {
+      "version": "20260501",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260501/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260501/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-05-01T04:25:33Z"
+    },
+    "20260420": {
+      "version": "20260420",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260420/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260420/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-04-20T04:06:06Z"
+    },
+    "20260406": {
+      "version": "20260406",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260406/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260406/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-04-06T10:36:54Z"
+    },
+    "20260401": {
+      "version": "20260401",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260401/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260401/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2026-04-01T03:55:56Z"
+    },
+    "20260324_314_alpha": {
+      "version": "20260324_314_alpha",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260324_314_alpha/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260324_314_alpha/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-03-24T07:39:35Z"
+    },
+    "20260320_314_alpha2": {
+      "version": "20260320_314_alpha2",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260320_314_alpha2/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260320_314_alpha2/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-03-20T10:15:46Z"
+    },
+    "20260320_314_alpha": {
+      "version": "20260320_314_alpha",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260320_314_alpha/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260320_314_alpha/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-03-20T08:26:51Z"
+    },
+    "20260320": {
+      "version": "20260320",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260320/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260320/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "published_at": "2026-03-20T03:10:15Z"
+    },
+    "20260301": {
+      "version": "20260301",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260301/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260301/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.0",
+      "published_at": "2026-03-01T03:22:56Z"
+    },
+    "20260220": {
+      "version": "20260220",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260220/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260220/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "5.0.0",
+      "published_at": "2026-02-20T03:10:55Z"
+    },
+    "20260210": {
+      "version": "20260210",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260210/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260210/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2026-02-10T03:27:03Z"
+    },
+    "20260201": {
+      "version": "20260201",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260201/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260201/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2026-02-01T03:26:27Z"
+    },
+    "20260127": {
+      "version": "20260127",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260127/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260127/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2026-01-27T05:41:41Z"
+    },
+    "20260120": {
+      "version": "20260120",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260120/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260120/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2026-01-20T02:38:48Z"
+    },
+    "20260110": {
+      "version": "20260110",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260110/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260110/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2026-01-10T02:34:50Z"
+    },
+    "20260101": {
+      "version": "20260101",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260101/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20260101/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2026-01-01T02:53:30Z"
+    },
+    "20251220": {
+      "version": "20251220",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251220/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251220/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-12-20T02:29:47Z"
+    },
+    "20251216": {
+      "version": "20251216",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251216/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251216/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-12-16T05:48:32Z"
+    },
+    "20251210": {
+      "version": "20251210",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251210/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251210/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-12-10T02:34:02Z"
+    },
+    "20251201": {
+      "version": "20251201",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251201/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251201/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-12-01T02:53:16Z"
+    },
+    "20251120": {
+      "version": "20251120",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251120/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251120/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-11-20T02:26:40Z"
+    },
+    "20251110": {
+      "version": "20251110",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251110/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251110/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-11-10T02:33:49Z"
+    },
+    "20251101": {
+      "version": "20251101",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251101/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251101/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-11-01T02:31:59Z"
+    },
+    "20251020": {
+      "version": "20251020",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251020/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251020/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-10-20T02:30:40Z"
+    },
+    "20251010": {
+      "version": "20251010",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251010/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251010/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-10-10T02:20:53Z"
+    },
+    "20251001": {
+      "version": "20251001",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251001/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20251001/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-10-01T02:31:28Z"
+    },
+    "20250920": {
+      "version": "20250920",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250920/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250920/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-09-20T02:17:04Z"
+    },
+    "20250910": {
+      "version": "20250910",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250910/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250910/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-09-10T02:17:36Z"
+    },
+    "20250901": {
+      "version": "20250901",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250901/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250901/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-09-01T02:37:11Z"
+    },
+    "20250820": {
+      "version": "20250820",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250820/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250820/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-08-20T02:27:13Z"
+    },
+    "20250810": {
+      "version": "20250810",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250810/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250810/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-08-10T02:53:47Z"
+    },
+    "20250801": {
+      "version": "20250801",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250801/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250801/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-08-02T08:24:49Z"
+    },
+    "20250703": {
+      "version": "20250703",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250703/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250703/xbuildenv-debug.tar.bz2",
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-07-02T23:27:43Z"
+    },
+    "20250701": {
+      "version": "20250701",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250701/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-07-01T02:43:20Z"
+    },
+    "20250626": {
+      "version": "20250626",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250626/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-06-26T13:54:14Z"
+    },
+    "20250620": {
+      "version": "20250620",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250620/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-06-20T02:30:10Z"
+    },
+    "20250610": {
+      "version": "20250610",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250610/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-06-10T02:34:10Z"
+    },
+    "20250604": {
+      "version": "20250604",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250604/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-06-04T14:57:16Z"
+    },
+    "20250601": {
+      "version": "20250601",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250601/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-06-01T02:52:33Z"
+    },
+    "20250523-emscripten_4.0.9": {
+      "version": "20250523-emscripten_4.0.9",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250523-emscripten_4.0.9/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.9",
+      "published_at": "2025-05-23T11:40:30Z"
+    },
+    "20250520": {
+      "version": "20250520",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250520/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.8",
+      "published_at": "2025-05-20T02:28:24Z"
+    },
+    "20250510": {
+      "version": "20250510",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250510/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.8",
+      "published_at": "2025-05-10T02:23:26Z"
+    },
+    "20250503": {
+      "version": "20250503",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250503/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.8",
+      "published_at": "2025-05-03T02:34:17Z"
+    },
+    "20250501": {
+      "version": "20250501",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250501/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.7",
+      "published_at": "2025-05-01T02:36:02Z"
+    },
+    "20250426": {
+      "version": "20250426",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250426/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.7",
+      "published_at": "2025-04-25T23:56:04Z"
+    },
+    "20250420": {
+      "version": "20250420",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250420/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.6",
+      "published_at": "2025-04-20T02:32:43Z"
+    },
+    "20250410": {
+      "version": "20250410",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250410/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.6",
+      "published_at": "2025-04-10T02:22:48Z"
+    },
+    "20250407": {
+      "version": "20250407",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250407/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.13.2",
+      "emscripten_version": "4.0.6",
+      "published_at": "2025-04-07T12:25:26Z"
+    },
+    "20250320": {
+      "version": "20250320",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250320/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.12.7",
+      "emscripten_version": "3.1.74",
+      "published_at": "2025-03-20T02:16:08Z"
+    },
+    "20250313": {
+      "version": "20250313",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250313/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.12.7",
+      "emscripten_version": "3.1.74",
+      "published_at": "2025-03-13T13:19:19Z"
+    },
+    "20250307": {
+      "version": "20250307",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250307/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.12.7",
+      "emscripten_version": "3.1.74",
+      "published_at": "2025-03-07T09:42:09Z"
+    },
+    "20250228": {
+      "version": "20250228",
+      "url": "https://github.com/pyodide/pyodide-build-environment-nightly/releases/download/20250228/xbuildenv.tar.bz2",
+      "sha256": null,
+      "debug_url": null,
+      "debug_sha256": null,
+      "python_version": "3.12.7",
+      "emscripten_version": "3.1.74",
+      "published_at": "2025-02-28T11:49:13Z"
+    }
+  }
+}

--- a/tools/update_nightly_cross_build_releases.py
+++ b/tools/update_nightly_cross_build_releases.py
@@ -1,0 +1,168 @@
+# /// script
+# dependencies = ["requests"]
+# ///
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+import requests
+
+REPO = "pyodide/pyodide-build-environment-nightly"
+BASE_URL = "https://github.com/{repo}/releases/download/{version}/{filename}"
+RELEASE_FILENAME = "xbuildenv.tar.bz2"
+DEBUG_FILENAME = "xbuildenv-debug.tar.bz2"
+
+METADATA_FILE = Path(__file__).parents[1] / "nightly-cross-build-environments.json"
+EMPTY_METADATA = '{"releases": {}}'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        "Update the nightly cross-build environments metadata file"
+    )
+    parser.add_argument("version", help="The nightly version tag (say, 20260520)")
+    return parser.parse_args()
+
+
+# If you want to test this locally, you can set a short-lived token
+# with GITHUB_TOKEN=$(gh auth token --scopes repo) to avoid hitting the rate limit.
+def _github_headers() -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def get_archive(url: str) -> bytes | None:
+    resp = requests.get(url)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.content
+
+
+def get_published_at(version: str) -> str:
+    url = f"https://api.github.com/repos/{REPO}/releases/tags/{version}"
+    resp = requests.get(url, headers=_github_headers())
+    resp.raise_for_status()
+    return resp.json()["published_at"]
+
+
+def parse_env_var(content: str, var_name: str) -> str:
+    for line in content.splitlines():
+        if line.startswith(f"export {var_name}"):
+            return line.split("=")[1].strip()
+    return ""
+
+
+@contextmanager
+def extract_archive(archive: bytes) -> Generator[Path]:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir_path = Path(tmp_dir)
+        archive_path = tmp_dir_path / "xbuildenv.tar.bz2"
+        archive_path.write_bytes(archive)
+        shutil.unpack_archive(str(archive_path), extract_dir=tmp_dir)
+        yield tmp_dir_path
+
+
+def _version_sort_key(tag: str) -> tuple[int, str]:
+    date_part = int(tag[:8]) if len(tag) >= 8 and tag[:8].isdigit() else 0
+    return (date_part, tag)
+
+
+def add_version(
+    raw_metadata: str,
+    version: str,
+    url: str,
+    sha256: str,
+    debug_url: str | None,
+    debug_sha256: str | None,
+    python_version: str,
+    emscripten_version: str,
+    published_at: str | None,
+) -> str:
+    metadata = json.loads(raw_metadata)
+    metadata["releases"][version] = {
+        "version": version,
+        "url": url,
+        "sha256": sha256,
+        "debug_url": debug_url,
+        "debug_sha256": debug_sha256,
+        "python_version": python_version,
+        "emscripten_version": emscripten_version,
+        "published_at": published_at,
+    }
+    metadata["releases"] = dict(
+        sorted(
+            metadata["releases"].items(),
+            key=lambda x: _version_sort_key(x[0]),
+            reverse=True,
+        )
+    )
+    return json.dumps(metadata, indent=2)
+
+
+def main() -> None:
+    args = parse_args()
+    version = args.version
+
+    release_url = BASE_URL.format(repo=REPO, version=version, filename=RELEASE_FILENAME)
+    debug_url = BASE_URL.format(repo=REPO, version=version, filename=DEBUG_FILENAME)
+
+    print(f"Downloading release tarball for {version} ...")
+    release_content = get_archive(release_url)
+    if release_content is None:
+        sys.exit(f"Release tarball not found: {release_url}")
+    release_sha256 = hashlib.sha256(release_content).hexdigest()
+
+    with extract_archive(release_content) as extracted:
+        makefile_path = extracted / "xbuildenv" / "pyodide-root" / "Makefile.envs"
+        makefile_content = makefile_path.read_text()
+        python_version = parse_env_var(makefile_content, "PYVERSION")
+        emscripten_version = parse_env_var(
+            makefile_content, "PYODIDE_EMSCRIPTEN_VERSION"
+        )
+
+    print(f"Downloading debug tarball for {version} ...")
+    debug_content = get_archive(debug_url)
+    if debug_content is not None:
+        debug_sha256 = hashlib.sha256(debug_content).hexdigest()
+        print(f"  debug build found (sha256={debug_sha256[:12]}...)")
+    else:
+        debug_url = None
+        debug_sha256 = None
+        print("  no debug build for this version")
+
+    published_at = get_published_at(version)
+
+    raw = METADATA_FILE.read_text() if METADATA_FILE.exists() else EMPTY_METADATA
+    new_metadata = add_version(
+        raw,
+        version,
+        release_url,
+        release_sha256,
+        debug_url,
+        debug_sha256,
+        python_version,
+        emscripten_version,
+        published_at,
+    )
+    METADATA_FILE.write_text(new_metadata + "\n")
+    print(
+        f"Updated metadata for {version}: "
+        f"python={python_version} emscripten={emscripten_version} "
+        f"published_at={published_at} debug={'yes' if debug_sha256 else 'no'}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Adds a script to add v2 metadata for nightly cross-build environments in a JSON file (see generated JSON file)
- The `publish.yml` workflow file now pushes a commit to `main`. I chose to not use a PR because it adds a bit of churn, but I can change the approach if asked
- Added a `pages.yml` workflow to deploy the file on GitHub Pages

There is no v1 file here, just v2, because it's the first time we are doing it and it doesn't make sense to go with the old spec.

I will follow this up by putting together a PR in pyodide-build to use this metadata for those who would like to use nightly and nightly-debug builds.

xref https://github.com/pyodide/pyodide/pull/6248, https://github.com/pyodide/pyodide-build/pull/349