### PR TITLE
Deploy to GitHub Pages via `gh workflow run`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,3 +135,8 @@ jobs:
           git add nightly-cross-build-environments-release.json nightly-cross-build-environments-debug.json
           git commit -m "Scheduled update for nightly  ${VERSION} xbuildenvs metadata [skip ci]"
           git push origin main
+
+      - name: Deploy GitHub Pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages.yml --ref main


### PR DESCRIPTION
There are two reasons the `pages.yml` workflow isn't triggering for us right now:

- `GITHUB_TOKEN` commits don't trigger workflows to prevent infinite loops
- `[skip ci]` in the commit message

We can manually invoke the GitHub Pages deployment via `gh workflow run pages.yml`.
