### PR TITLE
Add release diagnostics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,17 +104,28 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STEPS_RELEASE_VERSION_OUTPUTS_RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Generate release notes
+        env:
+          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+        run: |
+          uv run tools/generate_release_notes.py \
+            "$RELEASE_VERSION" \
+            dist/xbuildenv.tar.bz2 \
+            dist/xbuildenv-debug.tar.bz2 \
+            > release-notes.md
+
       - name: Create GitHub release with these wheels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
         run: |
           gh release create "$RELEASE_VERSION" dist/*.tar.bz2 \
-            --title "$RELEASE_VERSION"
-
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: false
+            --title "$RELEASE_VERSION" \
+            --notes-file release-notes.md
 
       - name: Update cross-build environments metadata
         env:

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -1,0 +1,243 @@
+# /// script
+# dependencies = []
+# ///
+
+"""
+Generate release notes in Markdown for nightly xbuildenv release
+
+The data sources inside the tarball at the time of writing this script include:
+- xbuildenv/requirements.txt                    --> cross-build Python packages (pip freeze)
+- xbuildenv/pyodide-root/Makefile.envs          --> Emscripten and Python versions
+- xbuildenv/pyodide-root/dist/pyodide-lock.json --> Pyodide runtime packages
+- xbuildenv/site-packages-extras/**/*.a         --> static libraries
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tarfile
+from pathlib import Path
+
+
+def _parse_env_var(content: str, var_name: str) -> str:
+    for line in content.splitlines():
+        if line.startswith(f"export {var_name}"):
+            return line.split("=")[1].strip()
+    return ""
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _human_size(n: int) -> str:
+    size = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TiB"
+
+
+def _parse_requirements(content: str) -> list[dict[str, str]]:
+    """Parse pip freeze output into [{name, version}]"""
+    packages = []
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_.\-]+)==(.+)$", line)
+        if m:
+            packages.append({"name": m.group(1), "version": m.group(2)})
+    return sorted(packages, key=lambda p: p["name"].lower())
+
+
+def _scan_tarball(path: Path) -> dict:
+    """Extract all metadata from the tarball"""
+    result: dict = {
+        "emscripten_version": "",
+        "python_version": "",
+        "xbuildenv_packages": [],  # from requirements.txt
+        "runtime_packages": [],  # from pyodide-lock.json (package_type=package)
+        "runtime_libraries": [],  # from pyodide-lock.json (package_type=shared_library)
+        "static_libs": [],  # from .a files
+    }
+
+    with tarfile.open(path, "r:bz2") as tf:
+        for member in tf.getmembers():
+            if not member.isfile():
+                continue
+            name = member.name
+
+            if name.endswith("Makefile.envs"):
+                file = tf.extractfile(member)
+                if file:
+                    content = file.read().decode("utf-8", errors="replace")
+                    result["emscripten_version"] = _parse_env_var(
+                        content, "PYODIDE_EMSCRIPTEN_VERSION"
+                    )
+                    result["python_version"] = _parse_env_var(content, "PYVERSION")
+
+            elif (
+                name.endswith("requirements.txt")
+                and "xbuildenv/requirements.txt" in name
+            ):
+                file = tf.extractfile(member)
+                if file:
+                    content = file.read().decode("utf-8", errors="replace")
+                    result["xbuildenv_packages"] = _parse_requirements(content)
+
+            elif name.endswith("pyodide-lock.json"):
+                file = tf.extractfile(member)
+                if file:
+                    data = json.loads(file.read().decode("utf-8"))
+                    for pkg in sorted(
+                        data.get("packages", {}).values(),
+                        key=lambda p: p["name"].lower(),
+                    ):
+                        entry = {
+                            "name": pkg["name"],
+                            "version": pkg.get("version", ""),
+                            "sha256": pkg.get("sha256", ""),
+                            "file_name": pkg.get("file_name", ""),
+                        }
+                        if pkg.get("package_type") == "shared_library":
+                            result["runtime_libraries"].append(entry)
+                        else:
+                            result["runtime_packages"].append(entry)
+
+            elif name.endswith(".a"):
+                lib_file = Path(name).name
+                lib_name = re.sub(r"^lib", "", re.sub(r"\.a$", "", lib_file))
+                if lib_name:
+                    result["static_libs"].append(lib_name)
+
+    result["static_libs"].sort(key=str.lower)
+    return result
+
+
+def generate_markdown(
+    version: str,
+    release_path: Path | None,
+    debug_path: Path | None,
+) -> str:
+    lines: list[str] = [
+        f"# Pyodide nightly cross-build environment {version}",
+        "",
+    ]
+
+    primary_path = release_path or debug_path
+    if primary_path is None:
+        return "\n".join(lines)
+
+    data = _scan_tarball(primary_path)
+
+    # Environment
+    lines += [
+        "## Environment",
+        "",
+        "| Property | Value |",
+        "| --- | --- |",
+        f"| Python version | `{data['python_version']}` |",
+        f"| Emscripten version | `{data['emscripten_version']}` |",
+        "",
+    ]
+
+    # Artifacts
+    lines += [
+        "## Artifacts",
+        "",
+        "| File | Size | SHA-256 |",
+        "| --- | --- | --- |",
+    ]
+    for path in (release_path, debug_path):
+        if path and path.exists():
+            size = _human_size(path.stat().st_size)
+            checksum = _sha256_file(path)
+            lines.append(f"| `{path.name}` | {size} | `{checksum}` |")
+    lines.append("")
+
+    # Cross-build environment packages (requirements.txt)
+    if data["xbuildenv_packages"]:
+        lines += [
+            "## Cross-build environment packages",
+            "",
+            "Packages available for linking during cross-compilation.",
+            "",
+            "| Package | Version |",
+            "| --- | --- |",
+        ]
+        for pkg in data["xbuildenv_packages"]:
+            lines.append(f"| {pkg['name']} | `{pkg['version']}` |")
+        lines.append("")
+
+    # Pyodide runtime: Python packages
+    if data["runtime_packages"]:
+        lines += [
+            "## Pyodide runtime packages",
+            "",
+            "| Package | Version | SHA-256 |",
+            "| --- | --- | --- |",
+        ]
+        for pkg in data["runtime_packages"]:
+            lines.append(f"| {pkg['name']} | `{pkg['version']}` | `{pkg['sha256']}` |")
+        lines.append("")
+
+    # Pyodide runtime: shared libraries
+    if data["runtime_libraries"]:
+        lines += [
+            "## Pyodide runtime shared libraries",
+            "",
+            "| Library | Version | SHA-256 |",
+            "| --- | --- | --- |",
+        ]
+        for lib in data["runtime_libraries"]:
+            lines.append(f"| {lib['name']} | `{lib['version']}` | `{lib['sha256']}` |")
+        lines.append("")
+
+    # Static libraries (from .a files in site-packages-extras)
+    if data["static_libs"]:
+        lines += [
+            "## Static libraries",
+            "",
+            "| Library |",
+            "| --- |",
+        ]
+        for lib in data["static_libs"]:
+            lines.append(f"| {lib} |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate Markdown release notes for a nightly xbuildenv release"
+    )
+    parser.add_argument("version", help="Release version tag, i.e., 20260601)")
+    parser.add_argument("release_tarball", nargs="?", help="Path to xbuildenv.tar.bz2")
+    parser.add_argument(
+        "debug_tarball", nargs="?", help="Path to xbuildenv-debug.tar.bz2"
+    )
+    args = parser.parse_args()
+
+    release_path = Path(args.release_tarball) if args.release_tarball else None
+    debug_path = Path(args.debug_tarball) if args.debug_tarball else None
+
+    if release_path and not release_path.exists():
+        sys.exit(f"Release tarball not found: {release_path}")
+    if debug_path and not debug_path.exists():
+        print(f"Warning: debug tarball not found: {debug_path}", file=sys.stderr)
+        debug_path = None
+
+    print(generate_markdown(args.version, release_path, debug_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #22. This PR adds a script that we run at the time of creating a release, which adds Markdown release notes, so that we can quickly take a glance at what is inside the xbuildenv.

Here is a sample output from running the script on the 20260601 release:

```markdown
# Pyodide nightly cross-build environment 20260601

## Environment

| Property | Value |
| --- | --- |
| Python version | `3.14.2` |
| Emscripten version | `5.0.3` |

## Artifacts

| File | Size | SHA-256 |
| --- | --- | --- |
| `xbuildenv.tar.bz2` | 7.0 MiB | `a3b5198c89f35ea2cc8bc3ce452334a127542bb8701de57c04ff9f5608140420` |
| `xbuildenv-debug.tar.bz2` | 7.3 MiB | `c78e6ff6194141b0f90f98f93e1461e0f84b0e5f4c7cd52719a90df73bcf4768` |

## Cross-build environment packages

Packages available for linking during cross-compilation.

| Package | Version |
| --- | --- |
| cffi | `2.0.0` |
| numpy | `2.4.3` |
| pycparser | `3.0` |
| scipy | `1.17.0` |

## Pyodide runtime packages

| Package | Version | SHA-256 |
| --- | --- | --- |
| cffi | `2.0.0` | `16224fb6ffed356066647b0846f4f029cb0386881a0203b80a002f69603574ab` |
| micropip | `0.11.1` | `16aa67d77585c8357f9975b334d9742bfcf7e4a929f76eb484c171ec4361de9b` |
| numpy | `2.4.3` | `54d26672830ee4e47c99fc93a67895c5e128e48f152de402eb4bf8b9c631d450` |
| pycparser | `2.22` | `e1454a4b89fe6f48f5d8726c86bf8e72ff0486a02818cebdf5724401bea6409c` |
| pydoc_data | `1.0.0` | `48c7fae24646ee6b4b2480b66d18ea691273877187935471316eb02e08a8cb27` |
| scipy | `1.17.0` | `6223431a0f4ab4cf95a69942d21d2251875ee1f128de43c66dedd5c51f13b770` |
| scipy-tests | `1.17.0` | `d233ed370ba4d2a7a22471c598bed1c2b893cfeb90e813161e87ebf7739bb5c2` |
| test | `1.0.0` | `6abba0e0d24bc70566f619b3b4fbb7517fd05ae9cd3914870050d4be006fd33b` |

## Pyodide runtime shared libraries

| Library | Version | SHA-256 |
| --- | --- | --- |
| libopenblas | `0.3.28` | `52cd0efb4874642d33cd3f32093ea42f2fbb9ad4e46551d515a731320468f4b4` |

## Static libraries

| Library |
| --- |
| npymath |
| npyrandom |
```

That is, we include information about:
- The Python and Emscripten version
- What artifacts are provided by the release. There are both nightly xbuildenvs and nightly-debug xbuildenvs, and nightly xbuildenvs when we didn't have nightly-debug
- The cross-build environment packages (pycparser is shown because it's a transitive dependency. cffi depends on it)
- Pyodide runtime packages, with their SHA-256 checksums
- Static libraries that are available